### PR TITLE
Add alert description to alert payload

### DIFF
--- a/terraform/modules/account-alerts/lambda.tf
+++ b/terraform/modules/account-alerts/lambda.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
   alarm_description = <<EOF
 {
   "slack_channel": "dcp-ops",
-  "environment": "${var.env}"
+  "description": "Account-wide AWS Lambda Errors"
 }
 EOF
 
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
   alarm_description = <<EOF
 {
   "slack_channel": "dcp-ops",
-  "environment": "${var.env}"
+  "description": "Account-wide AWS Lambda Throttles"
 }
 EOF
 

--- a/terraform/modules/account-alerts/lambda.tf
+++ b/terraform/modules/account-alerts/lambda.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_errors" {
 
   alarm_description = <<EOF
 {
-  "slack_channel": "dcp-ops",
+  "slack_channel": "dcp-ops-alerts",
   "description": "Account-wide AWS Lambda Errors"
 }
 EOF
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "lambda_throttles" {
 
   alarm_description = <<EOF
 {
-  "slack_channel": "dcp-ops",
+  "slack_channel": "dcp-ops-alerts",
   "description": "Account-wide AWS Lambda Throttles"
 }
 EOF

--- a/terraform/modules/account-alerts/logs.tf
+++ b/terraform/modules/account-alerts/logs.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "logs_health" {
   alarm_description = <<EOF
 {
   "slack_channel": "dcp-security",
-  "environment": "${var.env}"
+  "description": "Logs Proxy and Elasticsearch availability healthcheck"
 }
 EOF
 
@@ -37,7 +37,7 @@ resource "aws_cloudwatch_metric_alarm" "logs_free_space" {
   alarm_description = <<EOF
 {
   "slack_channel": "dcp-security",
-  "environment": "${var.env}"
+  "description": "Logs Elasticsearch cluster free space"
 }
 EOF
 

--- a/terraform/modules/account-alerts/rds.tf
+++ b/terraform/modules/account-alerts/rds.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_low_disk" {
 
   alarm_description = <<EOF
 {
-  "slack_channel": "dcp-ops",
+  "slack_channel": "dcp-ops-alerts",
   "description": "AWS Relational Database Service node low on disk"
 }
 EOF
@@ -32,7 +32,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_high" {
 
   alarm_description = <<EOF
 {
-  "slack_channel": "dcp-ops",
+  "slack_channel": "dcp-ops-alerts",
   "description": "AWS Relational Database Service node CPU utilization high"
 }
 EOF

--- a/terraform/modules/account-alerts/rds.tf
+++ b/terraform/modules/account-alerts/rds.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_low_disk" {
   alarm_description = <<EOF
 {
   "slack_channel": "dcp-ops",
-  "environment": "${var.env}"
+  "description": "AWS Relational Database Service node low on disk"
 }
 EOF
 
@@ -33,7 +33,7 @@ resource "aws_cloudwatch_metric_alarm" "rds_cpu_high" {
   alarm_description = <<EOF
 {
   "slack_channel": "dcp-ops",
-  "environment": "${var.env}"
+  "description": "AWS Relational Database Service node CPU utilization high"
 }
 EOF
 

--- a/terraform/modules/env-alerts/analysis.tf
+++ b/terraform/modules/env-alerts/analysis.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "analysis" {
   alarm_description = <<EOF
 {
   "slack_channel": "mintteam",
-  "environment": "${var.env}"
+  "description": "DCP Analysis service availability healthcheck"
 }
 EOF
 

--- a/terraform/modules/env-alerts/dcp.tf
+++ b/terraform/modules/env-alerts/dcp.tf
@@ -10,7 +10,7 @@ resource "aws_cloudwatch_metric_alarm" "dcp" {
 
   alarm_description = <<EOF
 {
-  "slack_channel": "dcp-ops",
+  "slack_channel": "dcp-ops-alerts",
   "description": "Status of aggregated DCP availability healthchecks"
 }
 EOF

--- a/terraform/modules/env-alerts/dcp.tf
+++ b/terraform/modules/env-alerts/dcp.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "dcp" {
   alarm_description = <<EOF
 {
   "slack_channel": "dcp-ops",
-  "environment": "${var.env}"
+  "description": "Status of aggregated DCP availability healthchecks"
 }
 EOF
 

--- a/terraform/modules/env-alerts/dss.tf
+++ b/terraform/modules/env-alerts/dss.tf
@@ -12,6 +12,7 @@ resource "aws_cloudwatch_metric_alarm" "dss" {
 {
   "slack_channel": "data-store-eng",
   "environment": "${var.env}"
+  "description": "DCP Data Storage Service availability healthcheck"
 }
 EOF
 

--- a/terraform/modules/env-alerts/ingest.tf
+++ b/terraform/modules/env-alerts/ingest.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "ingest" {
   alarm_description = <<EOF
 {
   "slack_channel": "ingestion-service",
-  "environment": "${var.env}"
+  "description": "DCP Ingest Service availability healthcheck"
 }
 EOF
 

--- a/terraform/modules/env-alerts/upload.tf
+++ b/terraform/modules/env-alerts/upload.tf
@@ -11,7 +11,7 @@ resource "aws_cloudwatch_metric_alarm" "upload" {
   alarm_description = <<EOF
 {
   "slack_channel": "upload-service",
-  "environment": "${var.env}"
+  "description": "DCP Upload Service availability healthcheck"
 }
 EOF
 


### PR DESCRIPTION
# Need

* As a user of the DCP monitoring system
* I want informative messages with my system alerts
* so I can readily tell what is wrong with the system.

# Approach
This PR adds an alert description to alert payload. This will enable more informative slack alerts.