### PR TITLE
Add dashboard templates for secondary-analysis.

### DIFF
--- a/terraform/modules/env-dashboards/analysis-dashboard.tf
+++ b/terraform/modules/env-dashboards/analysis-dashboard.tf
@@ -47,23 +47,25 @@ locals {
   "editable": true,
   "gnetId": null,
   "graphTooltip": 0,
+  "iteration": 1543530543256,
   "links": [],
   "panels": [
     {
       "aliasColors": {},
-      "bars": false,
+      "bars": true,
       "dashLength": 10,
       "dashes": false,
       "datasource": "${local.gcp_analysis_datasource_name}",
       "fill": 1,
       "gridPos": {
-        "h": 8,
+        "h": 5,
         "w": 24,
         "x": 0,
         "y": 0
       },
-      "id": 2,
+      "id": 9,
       "legend": {
+        "alignAsTable": false,
         "avg": false,
         "current": false,
         "max": false,
@@ -73,10 +75,10 @@ locals {
         "total": false,
         "values": false
       },
-      "lines": true,
-      "linewidth": 1,
+      "lines": false,
+      "linewidth": 2,
       "links": [],
-      "nullPointMode": "null",
+      "nullPointMode": "null as zero",
       "percentage": false,
       "pointradius": 5,
       "points": false,
@@ -84,16 +86,16 @@ locals {
       "seriesOverrides": [],
       "spaceLength": 10,
       "stack": false,
-      "steppedLine": false,
+      "steppedLine": true,
       "targets": [
         {
           "aggregation": {
-            "alignmentPeriod": "",
+            "alignmentPeriod": "$interval",
             "crossSeriesReducer": "REDUCE_NONE",
             "groupByFields": [],
             "perSeriesAligner": "ALIGN_NONE"
           },
-          "alias": "",
+          "alias": "Lira-notification-receipt",
           "bucketAggs": [
             {
               "field": "@timestamp",
@@ -129,12 +131,12 @@ locals {
         },
         {
           "aggregation": {
-            "alignmentPeriod": "",
+            "alignmentPeriod": "$interval",
             "crossSeriesReducer": "REDUCE_NONE",
             "groupByFields": [],
             "perSeriesAligner": "ALIGN_NONE"
           },
-          "alias": "",
+          "alias": "Cromwell-receipt",
           "filter": "",
           "format": "time_series",
           "metricType": "logging.googleapis.com/user/Lira-Cromwell-receipt",
@@ -151,7 +153,7 @@ locals {
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Lira(Listener) Receipt Counts",
+      "title": "Notification receipt and Workflow submission Count",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -167,6 +169,7 @@ locals {
       },
       "yaxes": [
         {
+          "decimals": 0,
           "format": "short",
           "label": null,
           "logBase": 1,
@@ -190,18 +193,19 @@ locals {
     },
     {
       "aliasColors": {},
-      "bars": true,
+      "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "${local.gcp_analysis_datasource_name}",
-      "fill": 1,
+      "description": "This is designed to be discrete.",
+      "fill": 4,
       "gridPos": {
-        "h": 9,
+        "h": 5,
         "w": 12,
         "x": 0,
-        "y": 8
+        "y": 5
       },
-      "id": 4,
+      "id": 11,
       "legend": {
         "avg": false,
         "current": false,
@@ -211,13 +215,13 @@ locals {
         "total": false,
         "values": false
       },
-      "lines": false,
-      "linewidth": 1,
+      "lines": true,
+      "linewidth": 2,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
       "pointradius": 0.5,
-      "points": false,
+      "points": true,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -231,7 +235,7 @@ locals {
             "groupByFields": [],
             "perSeriesAligner": "ALIGN_NONE"
           },
-          "alias": "Falcon-Queue-Update-HeartBeat",
+          "alias": "Falcon-Queue-Handler-HeartBeat",
           "bucketAggs": [
             {
               "field": "@timestamp",
@@ -273,7 +277,7 @@ locals {
             "groupByFields": [],
             "perSeriesAligner": "ALIGN_NONE"
           },
-          "alias": "Falcon-Queue-Effective-Update",
+          "alias": "Falcon-Queue-Handler-Enqueued-Workflow(s)",
           "filter": "resource.labels.cluster_name=\"green-100-us-central1\"",
           "format": "time_series",
           "metricType": "logging.googleapis.com/user/Falcon-queue-handler-effective-update",
@@ -287,32 +291,16 @@ locals {
           }
         }
       ],
-      "thresholds": [
-        {
-          "colorMode": "critical",
-          "fill": true,
-          "line": true,
-          "op": "lt",
-          "value": 0.5,
-          "yaxis": "left"
-        },
-        {
-          "colorMode": "critical",
-          "fill": true,
-          "line": true,
-          "op": "gt",
-          "value": 2,
-          "yaxis": "left"
-        }
-      ],
+      "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Falcon (Workflow Throttle) Queue Update Count",
+      "title": "Falcon (Workflow Throttle) Queue handler HeartBeat",
       "tooltip": {
-        "shared": false,
+        "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": false,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -323,7 +311,8 @@ locals {
       },
       "yaxes": [
         {
-          "format": "short",
+          "decimals": 0,
+          "format": "opm",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -346,18 +335,19 @@ locals {
     },
     {
       "aliasColors": {},
-      "bars": true,
+      "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "${local.gcp_analysis_datasource_name}",
-      "fill": 1,
+      "description": "This is designed to be discrete.",
+      "fill": 4,
       "gridPos": {
-        "h": 9,
+        "h": 5,
         "w": 12,
         "x": 12,
-        "y": 8
+        "y": 5
       },
-      "id": 5,
+      "id": 12,
       "legend": {
         "avg": false,
         "current": false,
@@ -367,13 +357,13 @@ locals {
         "total": false,
         "values": false
       },
-      "lines": false,
-      "linewidth": 1,
+      "lines": true,
+      "linewidth": 2,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
       "pointradius": 0.5,
-      "points": false,
+      "points": true,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -429,7 +419,7 @@ locals {
             "groupByFields": [],
             "perSeriesAligner": "ALIGN_NONE"
           },
-          "alias": "Falcon-Igniter-Workflow-Release",
+          "alias": "Falcon-Igniter-Released-Workflow(s)",
           "filter": "resource.labels.cluster_name=\"green-100-us-central1\"",
           "format": "time_series",
           "metricType": "logging.googleapis.com/user/Falcon-igniter-effective-release",
@@ -443,24 +433,118 @@ locals {
           }
         }
       ],
-      "thresholds": [
-        {
-          "colorMode": "critical",
-          "fill": true,
-          "line": true,
-          "op": "lt",
-          "value": 0.5,
-          "yaxis": "left"
-        }
-      ],
+      "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Falcon (Workflow Throttle) Workflow Release Count",
+      "title": "Falcon (Workflow Throttle) Workflow Igniter HeartBeat",
       "tooltip": {
-        "shared": false,
+        "shared": true,
         "sort": 0,
         "value_type": "individual"
       },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "decimals": 0,
+          "format": "opm",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "decimals": null,
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 10
+      },
+      "id": 2,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "$interval",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "GCE VM Instance: {{metric.labels.instance_name}}",
+          "filter": "metric.labels.instance_name!=starts_with(\"ggp-\")",
+          "format": "time_series",
+          "metricType": "compute.googleapis.com/instance/cpu/utilization",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Infrastructural VM Instances CPU Utilization",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
       "type": "graph",
       "xaxis": {
         "buckets": null,
@@ -494,20 +578,363 @@ locals {
     },
     {
       "aliasColors": {},
-      "bars": true,
+      "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "${local.gcp_analysis_datasource_name}",
-      "fill": 2,
+      "decimals": null,
+      "fill": 3,
       "gridPos": {
-        "h": 10,
+        "h": 8,
         "w": 12,
-        "x": 0,
-        "y": 17
+        "x": 12,
+        "y": 10
       },
-      "id": 7,
+      "id": 4,
       "legend": {
         "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "$interval",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Read Operations on VM Instance: {{metric.labels.instance_name}}",
+          "filter": "metric.labels.device_name!=starts_with(\"disk-1\") AND metric.labels.instance_name!=starts_with(\"ggp-\")",
+          "format": "time_series",
+          "metricType": "compute.googleapis.com/instance/disk/read_ops_count",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        },
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Write Operations on VM Instance: {{metric.labels.instance_name}}",
+          "filter": "metric.labels.device_name!=starts_with(\"disk-1\") AND metric.labels.instance_name!=starts_with(\"ggp-\")",
+          "format": "time_series",
+          "metricType": "compute.googleapis.com/instance/disk/write_ops_count",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "B",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Infrastructural VM Instances Disk I/O Activity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "decimals": null,
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 18
+      },
+      "id": 3,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "$interval",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "GCE VM Instance: {{metric.labels.instance_name}}",
+          "filter": "metric.labels.instance_name=starts_with(\"ggp-\")",
+          "format": "time_series",
+          "metricType": "compute.googleapis.com/instance/cpu/utilization",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Workflow Temporary Worker VMs CPU Utilization",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "decimals": null,
+      "fill": 3,
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 18
+      },
+      "id": 5,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": true,
+      "pointradius": 1,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "$interval",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Read Operations on VM Instance: {{metric.labels.instance_name}}",
+          "filter": "metric.labels.device_name!=starts_with(\"disk-1\") AND metric.labels.instance_name=starts_with(\"ggp-\")",
+          "format": "time_series",
+          "metricType": "compute.googleapis.com/instance/disk/read_ops_count",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        },
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Write Operations on VM Instance: {{metric.labels.instance_name}}",
+          "filter": "metric.labels.device_name!=starts_with(\"disk-1\") AND metric.labels.instance_name=starts_with(\"ggp-\")",
+          "format": "time_series",
+          "metricType": "compute.googleapis.com/instance/disk/write_ops_count",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "B",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Infrastructural VM Instances Disk R/W Activity",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "fill": 3,
+      "gridPos": {
+        "h": 5,
+        "w": 12,
+        "x": 0,
+        "y": 26
+      },
+      "id": 14,
+      "legend": {
+        "alignAsTable": false,
         "avg": false,
         "current": false,
         "max": false,
@@ -518,7 +945,7 @@ locals {
         "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 2,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
@@ -532,10 +959,12 @@ locals {
       "targets": [
         {
           "aggregation": {
-            "alignmentPeriod": "",
-            "crossSeriesReducer": "REDUCE_NONE",
-            "groupByFields": [],
-            "perSeriesAligner": "ALIGN_NONE"
+            "alignmentPeriod": "$interval",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "groupByFields": [
+              "metric.labels.method"
+            ],
+            "perSeriesAligner": "ALIGN_RATE"
           },
           "alias": "Method: {{metric.labels.method}}",
           "filter": "resource.labels.bucket_name=\"${var.gcp_analysis_project_id}-cromwell-execution\" ",
@@ -554,7 +983,7 @@ locals {
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "GCS Cromwell Execution Bucket Requests Count",
+      "title": "GCS Cromwell Execution Bucket Requests Rate",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -570,7 +999,7 @@ locals {
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "reqps",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -593,20 +1022,20 @@ locals {
     },
     {
       "aliasColors": {},
-      "bars": true,
+      "bars": false,
       "dashLength": 10,
       "dashes": false,
       "datasource": "${local.gcp_analysis_datasource_name}",
-      "fill": 2,
+      "fill": 3,
       "gridPos": {
-        "h": 10,
+        "h": 5,
         "w": 12,
         "x": 12,
-        "y": 17
+        "y": 26
       },
-      "id": 10,
+      "id": 15,
       "legend": {
-        "alignAsTable": true,
+        "alignAsTable": false,
         "avg": false,
         "current": false,
         "max": false,
@@ -617,7 +1046,7 @@ locals {
         "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 2,
       "links": [],
       "nullPointMode": "null as zero",
       "percentage": false,
@@ -631,10 +1060,12 @@ locals {
       "targets": [
         {
           "aggregation": {
-            "alignmentPeriod": "",
-            "crossSeriesReducer": "REDUCE_NONE",
-            "groupByFields": [],
-            "perSeriesAligner": "ALIGN_NONE"
+            "alignmentPeriod": "$interval",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "groupByFields": [
+              "metric.labels.method"
+            ],
+            "perSeriesAligner": "ALIGN_RATE"
           },
           "alias": "Method: {{metric.labels.method}}",
           "filter": "resource.labels.bucket_name=\"${var.gcp_analysis_project_id}-cromwell-execution\" \nmetric.labels.method=\"ReadObject\" OR metric.labels.method=\"WriteObject\"",
@@ -653,7 +1084,7 @@ locals {
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "GCS Cromwell Execution Bucket Read/Write Count",
+      "title": "GCS Cromwell Execution Bucket Requests Rate",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -669,7 +1100,7 @@ locals {
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "reqps",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -697,236 +1128,14 @@ locals {
       "dashes": false,
       "datasource": "${local.gcp_analysis_datasource_name}",
       "decimals": null,
-      "fill": 1,
-      "gridPos": {
-        "h": 15,
-        "w": 12,
-        "x": 0,
-        "y": 27
-      },
-      "id": 12,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 1,
-      "points": true,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "aggregation": {
-            "alignmentPeriod": "",
-            "crossSeriesReducer": "REDUCE_NONE",
-            "groupByFields": [],
-            "perSeriesAligner": "ALIGN_NONE"
-          },
-          "alias": "GCE VM Instance: {{metric.labels.instance_name}}",
-          "filter": "",
-          "format": "time_series",
-          "metricType": "compute.googleapis.com/instance/cpu/utilization",
-          "mode": "monitoring",
-          "projectId": "",
-          "refId": "A",
-          "seriesFilter": {
-            "mode": "NONE",
-            "param": "",
-            "type": "NONE"
-          }
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "GCE VM Instances CPU Utilization",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": false,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${local.gcp_analysis_datasource_name}",
-      "decimals": null,
-      "fill": 1,
-      "gridPos": {
-        "h": 15,
-        "w": 12,
-        "x": 12,
-        "y": 27
-      },
-      "id": 14,
-      "legend": {
-        "alignAsTable": true,
-        "avg": false,
-        "current": true,
-        "max": false,
-        "min": false,
-        "rightSide": false,
-        "show": true,
-        "total": false,
-        "values": true
-      },
-      "lines": true,
-      "linewidth": 1,
-      "links": [],
-      "nullPointMode": "null",
-      "percentage": false,
-      "pointradius": 1,
-      "points": true,
-      "renderer": "flot",
-      "seriesOverrides": [],
-      "spaceLength": 10,
-      "stack": false,
-      "steppedLine": false,
-      "targets": [
-        {
-          "aggregation": {
-            "alignmentPeriod": "",
-            "crossSeriesReducer": "REDUCE_NONE",
-            "groupByFields": [],
-            "perSeriesAligner": "ALIGN_NONE"
-          },
-          "alias": "Read Ops: VM Instance: {{metric.labels.instance_name}}",
-          "filter": "",
-          "format": "time_series",
-          "metricType": "compute.googleapis.com/instance/disk/read_ops_count",
-          "mode": "monitoring",
-          "projectId": "",
-          "refId": "A",
-          "seriesFilter": {
-            "mode": "NONE",
-            "param": "",
-            "type": "NONE"
-          }
-        },
-        {
-          "aggregation": {
-            "alignmentPeriod": "",
-            "crossSeriesReducer": "REDUCE_NONE",
-            "groupByFields": [],
-            "perSeriesAligner": "ALIGN_NONE"
-          },
-          "alias": "Write Ops: VM Instance: {{metric.labels.instance_name}}",
-          "filter": "",
-          "format": "time_series",
-          "metricType": "compute.googleapis.com/instance/disk/write_ops_count",
-          "mode": "monitoring",
-          "projectId": "",
-          "refId": "B",
-          "seriesFilter": {
-            "mode": "NONE",
-            "param": "",
-            "type": "NONE"
-          }
-        }
-      ],
-      "thresholds": [],
-      "timeFrom": null,
-      "timeShift": null,
-      "title": "GCE VM Instances Disk Utilization",
-      "tooltip": {
-        "shared": true,
-        "sort": 0,
-        "value_type": "individual"
-      },
-      "transparent": false,
-      "type": "graph",
-      "xaxis": {
-        "buckets": null,
-        "mode": "time",
-        "name": null,
-        "show": true,
-        "values": []
-      },
-      "yaxes": [
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        },
-        {
-          "format": "short",
-          "label": null,
-          "logBase": 1,
-          "max": null,
-          "min": null,
-          "show": true
-        }
-      ],
-      "yaxis": {
-        "align": false,
-        "alignLevel": null
-      }
-    },
-    {
-      "aliasColors": {},
-      "bars": false,
-      "dashLength": 10,
-      "dashes": false,
-      "datasource": "${local.gcp_analysis_datasource_name}",
-      "decimals": null,
-      "fill": 1,
+      "fill": 5,
       "gridPos": {
         "h": 7,
         "w": 24,
         "x": 0,
-        "y": 42
+        "y": 31
       },
-      "id": 13,
+      "id": 7,
       "legend": {
         "alignAsTable": true,
         "avg": false,
@@ -939,12 +1148,12 @@ locals {
         "values": false
       },
       "lines": true,
-      "linewidth": 1,
+      "linewidth": 2,
       "links": [],
       "nullPointMode": "null",
       "percentage": false,
       "pointradius": 1,
-      "points": true,
+      "points": false,
       "renderer": "flot",
       "seriesOverrides": [],
       "spaceLength": 10,
@@ -953,12 +1162,14 @@ locals {
       "targets": [
         {
           "aggregation": {
-            "alignmentPeriod": "",
-            "crossSeriesReducer": "REDUCE_NONE",
-            "groupByFields": [],
-            "perSeriesAligner": "ALIGN_NONE"
+            "alignmentPeriod": "$interval",
+            "crossSeriesReducer": "REDUCE_SUM",
+            "groupByFields": [
+              "metric.labels.state"
+            ],
+            "perSeriesAligner": "ALIGN_RATE"
           },
-          "alias": "State: {{metric.labels.state}}",
+          "alias": "Status: {{metric.labels.state}}",
           "filter": "",
           "format": "time_series",
           "hide": false,
@@ -971,33 +1182,12 @@ locals {
             "param": "",
             "type": "NONE"
           }
-        },
-        {
-          "aggregation": {
-            "alignmentPeriod": "",
-            "crossSeriesReducer": "REDUCE_NONE",
-            "groupByFields": [],
-            "perSeriesAligner": "ALIGN_NONE"
-          },
-          "alias": "",
-          "filter": "",
-          "format": "time_series",
-          "hide": true,
-          "metricType": "compute.googleapis.com/instance/disk/read_ops_count",
-          "mode": "monitoring",
-          "projectId": "",
-          "refId": "B",
-          "seriesFilter": {
-            "mode": "NONE",
-            "param": "",
-            "type": "NONE"
-          }
         }
       ],
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Google Cloud API Request Count",
+      "title": "Google Cloud API Request Rate",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -1014,7 +1204,7 @@ locals {
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "reqps",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -1041,10 +1231,58 @@ locals {
   "style": "dark",
   "tags": [],
   "templating": {
-    "list": []
+    "list": [
+      {
+        "auto": false,
+        "auto_count": 30,
+        "auto_min": "10s",
+        "current": {
+          "text": "60s",
+          "value": "60s"
+        },
+        "hide": 0,
+        "label": null,
+        "name": "interval",
+        "options": [
+          {
+            "selected": false,
+            "text": "1s",
+            "value": "1s"
+          },
+          {
+            "selected": false,
+            "text": "5s",
+            "value": "5s"
+          },
+          {
+            "selected": false,
+            "text": "30s",
+            "value": "30s"
+          },
+          {
+            "selected": true,
+            "text": "60s",
+            "value": "60s"
+          },
+          {
+            "selected": false,
+            "text": "120s",
+            "value": "120s"
+          },
+          {
+            "selected": false,
+            "text": "300s",
+            "value": "300s"
+          }
+        ],
+        "query": "1s,5s,30s,60s,120s,300s",
+        "refresh": 2,
+        "type": "interval"
+      }
+    ]
   },
   "time": {
-    "from": "now-1h",
+    "from": "now-6h",
     "to": "now"
   },
   "timepicker": {
@@ -1075,7 +1313,7 @@ locals {
   "timezone": "",
   "title": "ANALYSIS [${upper(var.env)}]",
   "uid": "analysis-${var.env}",
-  "version": 39
+  "version": 27
 }
 EOF
 }

--- a/terraform/modules/env-dashboards/analysis-dashboard.tf
+++ b/terraform/modules/env-dashboards/analysis-dashboard.tf
@@ -659,7 +659,7 @@ locals {
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Infrastructural VM Instances Disk I/O Activity",
+      "title": "Infrastructural VM Instances Disk R/W Activity",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -760,7 +760,7 @@ locals {
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Workflow Temporary Worker VMs CPU Utilization",
+      "title": "Volatile Workflow Worker VMs CPU Utilization",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -881,7 +881,7 @@ locals {
       "thresholds": [],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Infrastructural VM Instances Disk R/W Activity",
+      "title": "Volatile Workflow Worker VM Instances Disk R/W Activity",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/terraform/modules/env-dashboards/analysis-dashboard.tf
+++ b/terraform/modules/env-dashboards/analysis-dashboard.tf
@@ -1,0 +1,1081 @@
+locals {
+  analysis_dashboard = <<EOF
+{
+  "__inputs": [
+    {
+      "name": "DS_GCP-ANALYSIS-${upper(var.env)}",
+      "label": "gcp-analysis-${var.env}",
+      "description": "",
+      "type": "datasource",
+      "pluginId": "mtanda-google-stackdriver-datasource",
+      "pluginName": "GoogleStackdriver"
+    }
+  ],
+  "__requires": [
+    {
+      "type": "grafana",
+      "id": "grafana",
+      "name": "Grafana",
+      "version": "5.2.3"
+    },
+    {
+      "type": "panel",
+      "id": "graph",
+      "name": "Graph",
+      "version": "5.0.0"
+    },
+    {
+      "type": "datasource",
+      "id": "mtanda-google-stackdriver-datasource",
+      "name": "GoogleStackdriver",
+      "version": "1.0.0"
+    }
+  ],
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": "-- Grafana --",
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "gnetId": null,
+  "graphTooltip": 0,
+  "links": [],
+  "panels": [
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "fill": 1,
+      "gridPos": {
+        "h": 8,
+        "w": 24,
+        "x": 0,
+        "y": 0
+      },
+      "id": 2,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "filter": "",
+          "format": "time_series",
+          "metricType": "logging.googleapis.com/user/Lira-notification-receipt",
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "mode": "monitoring",
+          "projectId": "",
+          "query": "@log_group:\"/gcp/${var.gcp_analysis_project_id}/container/~\" AND @message:\"INFO:lira.api.notifications:Notification received\"",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          },
+          "timeField": "@timestamp"
+        },
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "",
+          "filter": "",
+          "format": "time_series",
+          "metricType": "logging.googleapis.com/user/Lira-Cromwell-receipt",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "B",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Lira(Listener) Receipt Counts",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 0,
+        "y": 8
+      },
+      "id": 4,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 0.5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Falcon-Queue-Update-HeartBeat",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "filter": "resource.labels.cluster_name=\"green-100-us-central1\"",
+          "format": "time_series",
+          "hide": false,
+          "metricType": "logging.googleapis.com/user/Falcon-queue-handler-heartbeat",
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "mode": "monitoring",
+          "projectId": "",
+          "query": "@log_group:\"/gcp/${var.gcp_analysis_project_id}/container/~\" AND @message:\"INFO:falcon.falcon.queue_handler:QueueHandler\"",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          },
+          "timeField": "@timestamp"
+        },
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Falcon-Queue-Effective-Update",
+          "filter": "resource.labels.cluster_name=\"green-100-us-central1\"",
+          "format": "time_series",
+          "metricType": "logging.googleapis.com/user/Falcon-queue-handler-effective-update",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "B",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "lt",
+          "value": 0.5,
+          "yaxis": "left"
+        },
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "gt",
+          "value": 2,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Falcon (Workflow Throttle) Queue Update Count",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "fill": 1,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 8
+      },
+      "id": 5,
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": false,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 0.5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Falcon-Igniter-Heartbeat",
+          "bucketAggs": [
+            {
+              "field": "@timestamp",
+              "id": "2",
+              "settings": {
+                "interval": "auto",
+                "min_doc_count": 0,
+                "trimEdges": 0
+              },
+              "type": "date_histogram"
+            }
+          ],
+          "filter": "resource.labels.cluster_name=\"green-100-us-central1\"",
+          "format": "time_series",
+          "hide": false,
+          "metricType": "logging.googleapis.com/user/Falcon-igniter-heartbeat",
+          "metrics": [
+            {
+              "field": "select field",
+              "id": "1",
+              "type": "count"
+            }
+          ],
+          "mode": "monitoring",
+          "projectId": "",
+          "query": "@log_group:\"/gcp/${var.gcp_analysis_project_id}/container/~\" AND @message:\"INFO:falcon.falcon.queue_handler:QueueHandler\"",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          },
+          "timeField": "@timestamp"
+        },
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Falcon-Igniter-Workflow-Release",
+          "filter": "resource.labels.cluster_name=\"green-100-us-central1\"",
+          "format": "time_series",
+          "metricType": "logging.googleapis.com/user/Falcon-igniter-effective-release",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "B",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [
+        {
+          "colorMode": "critical",
+          "fill": true,
+          "line": true,
+          "op": "lt",
+          "value": 0.5,
+          "yaxis": "left"
+        }
+      ],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Falcon (Workflow Throttle) Workflow Release Count",
+      "tooltip": {
+        "shared": false,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "fill": 2,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 0,
+        "y": 17
+      },
+      "id": 7,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": true,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Method: {{metric.labels.method}}",
+          "filter": "resource.labels.bucket_name=\"${var.gcp_analysis_project_id}-cromwell-execution\" ",
+          "format": "time_series",
+          "metricType": "storage.googleapis.com/api/request_count",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "GCS Cromwell Execution Bucket Requests Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": true,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "fill": 2,
+      "gridPos": {
+        "h": 10,
+        "w": 12,
+        "x": 12,
+        "y": 17
+      },
+      "id": 10,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null as zero",
+      "percentage": false,
+      "pointradius": 5,
+      "points": false,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Method: {{metric.labels.method}}",
+          "filter": "resource.labels.bucket_name=\"${var.gcp_analysis_project_id}-cromwell-execution\" \nmetric.labels.method=\"ReadObject\" OR metric.labels.method=\"WriteObject\"",
+          "format": "time_series",
+          "metricType": "storage.googleapis.com/api/request_count",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "GCS Cromwell Execution Bucket Read/Write Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "cumulative"
+      },
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "decimals": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 15,
+        "w": 12,
+        "x": 0,
+        "y": 27
+      },
+      "id": 12,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "GCE VM Instance: {{metric.labels.instance_name}}",
+          "filter": "",
+          "format": "time_series",
+          "metricType": "compute.googleapis.com/instance/cpu/utilization",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "GCE VM Instances CPU Utilization",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "decimals": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 15,
+        "w": 12,
+        "x": 12,
+        "y": 27
+      },
+      "id": 14,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": true,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": true
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Read Ops: VM Instance: {{metric.labels.instance_name}}",
+          "filter": "",
+          "format": "time_series",
+          "metricType": "compute.googleapis.com/instance/disk/read_ops_count",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        },
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "Write Ops: VM Instance: {{metric.labels.instance_name}}",
+          "filter": "",
+          "format": "time_series",
+          "metricType": "compute.googleapis.com/instance/disk/write_ops_count",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "B",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "GCE VM Instances Disk Utilization",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "${local.gcp_analysis_datasource_name}",
+      "decimals": null,
+      "fill": 1,
+      "gridPos": {
+        "h": 7,
+        "w": 24,
+        "x": 0,
+        "y": 42
+      },
+      "id": 13,
+      "legend": {
+        "alignAsTable": true,
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "rightSide": false,
+        "show": true,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 1,
+      "links": [],
+      "nullPointMode": "null",
+      "percentage": false,
+      "pointradius": 1,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "State: {{metric.labels.state}}",
+          "filter": "",
+          "format": "time_series",
+          "hide": false,
+          "metricType": "agent.googleapis.com/agent/api_request_count",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "A",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        },
+        {
+          "aggregation": {
+            "alignmentPeriod": "",
+            "crossSeriesReducer": "REDUCE_NONE",
+            "groupByFields": [],
+            "perSeriesAligner": "ALIGN_NONE"
+          },
+          "alias": "",
+          "filter": "",
+          "format": "time_series",
+          "hide": true,
+          "metricType": "compute.googleapis.com/instance/disk/read_ops_count",
+          "mode": "monitoring",
+          "projectId": "",
+          "refId": "B",
+          "seriesFilter": {
+            "mode": "NONE",
+            "param": "",
+            "type": "NONE"
+          }
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeShift": null,
+      "title": "Google Cloud API Request Count",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": false,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    }
+  ],
+  "refresh": false,
+  "schemaVersion": 16,
+  "style": "dark",
+  "tags": [],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-1h",
+    "to": "now"
+  },
+  "timepicker": {
+    "refresh_intervals": [
+      "5s",
+      "10s",
+      "30s",
+      "1m",
+      "5m",
+      "15m",
+      "30m",
+      "1h",
+      "2h",
+      "1d"
+    ],
+    "time_options": [
+      "5m",
+      "15m",
+      "1h",
+      "6h",
+      "12h",
+      "24h",
+      "2d",
+      "7d",
+      "30d"
+    ]
+  },
+  "timezone": "",
+  "title": "ANALYSIS [${upper(var.env)}]",
+  "uid": "analysis-${var.env}",
+  "version": 39
+}
+EOF
+}

--- a/terraform/modules/env-dashboards/analysis-dashboard.tf
+++ b/terraform/modules/env-dashboards/analysis-dashboard.tf
@@ -555,7 +555,7 @@ locals {
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "percentunit",
           "label": null,
           "logBase": 1,
           "max": null,
@@ -777,7 +777,7 @@ locals {
       },
       "yaxes": [
         {
-          "format": "short",
+          "format": "percentunit",
           "label": null,
           "logBase": 1,
           "max": null,

--- a/terraform/modules/env-dashboards/outputs.tf
+++ b/terraform/modules/env-dashboards/outputs.tf
@@ -21,7 +21,8 @@ output "dashboards" {
   ${local.dcp_dashboard},
   ${local.dss_dashboard},
   ${local.upload_dashboard},
-  ${local.azul_dashboard}
+  ${local.azul_dashboard},
+  ${local.analysis_dashboard}
 ]
 EOF
 }


### PR DESCRIPTION
This PR creates the dashboard templates for secondary-analysis following the instructions. The example dashboard is already on the dev Grafana instance named "analysis-staging".

I'm not sure about the correctness of the parameterization of the data sources in Terraform, so please point out if there is anything weird.