### PR TITLE
DSS env-alert: env check

### DIFF
--- a/terraform/modules/env-alerts/dss.tf
+++ b/terraform/modules/env-alerts/dss.tf
@@ -82,6 +82,7 @@ EOF
 }
 
 resource "aws_cloudwatch_metric_alarm" "dss-sync-failure" {
+  count = "${contains(list("staging", "prod"), var.env)? 1: 0 }"
   alarm_name          = "dss-sync-alert-${var.env}"
   comparison_operator = "GreaterThanOrEqualToThreshold"
   evaluation_periods  = "1"


### PR DESCRIPTION
Only deploys `staging` and `prod` version of the sync alert failures