### PR TITLE
Fix service type for last analysis panel

### DIFF
--- a/terraform/modules/env-dashboards/analysis-dashboard.tf
+++ b/terraform/modules/env-dashboards/analysis-dashboard.tf
@@ -1216,6 +1216,7 @@ locals {
           "metricType": "agent.googleapis.com/agent/api_request_count",
           "mode": "monitoring",
           "projectId": "",
+          "service": "storage",
           "refId": "A",
           "seriesFilter": {
             "mode": "NONE",


### PR DESCRIPTION
Grafana throws an error when trying to visualize logs for the "Google Cloud API request rate" graph on the analysis dashboard. Changing the service type from "agent", which appears to be the default, to "storage" fixes this issue.